### PR TITLE
Regenerate man/*.Rd + fix two roxygen blocks (clears CI WARNINGs)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     GGally,
     rlang,
     S4Vectors,
+    sna,
     tidyr
 LinkingTo: Rcpp
 Suggests:

--- a/R/ggplots_new.R
+++ b/R/ggplots_new.R
@@ -74,13 +74,18 @@ gglollipop_internal <- function(resultFis,
 #'
 #' Scatter NES vs significance, highlighting significant gene sets.
 #'
-#' @param resultFis data.frame with GSEA results (columns: NES, pval or Pvalue, padj or Padj)
+#' @param resultFis data.frame with GSEA or ORA results (columns vary; NES/pval/padj for GSEA, FoldEnrichment/Pvalue/Padj for ORA)
 #' @param top max number of top terms to display (default 50)
 #' @param pvalue p-value cutoff
-#' @param padj adjusted-p cutoff
-#' @param sig.color colour for significant points (default \code{"#b2182b"})
-#' @param ns.color colour for non-significant points (default \code{"grey70"})
-#' @param point.size point size (default 3)
+#' @param padj adjusted-p cutoff (overrides \code{pvalue} when supplied)
+#' @param usePadj logical, use adjusted p-value column for significance (default TRUE)
+#' @param low colour for down-regulated (negative-effect) points (default \code{"#2166ac"})
+#' @param mid colour at zero effect (default \code{"white"})
+#' @param high colour for up-regulated (positive-effect) points (default \code{"#b2182b"})
+#' @param size.range numeric length-2, min/max point sizes mapped from -log10(p) (default \code{c(2, 8)})
+#' @param label.size font size for point labels (default 3)
+#' @param label.top number of top terms to label (default 5)
+#' @param short logical, shorten term names via \code{.paste.char()} (default FALSE)
 #' @param filename if non-NULL, save the plot to this file
 #' @param width figure width
 #' @param height figure height

--- a/R/ggplots_new_methods.R
+++ b/R/ggplots_new_methods.R
@@ -563,6 +563,8 @@ setMethod("richGeneDot", signature(object = "GSEAResult"), function(object, fc =
 #' @param low colour for negative FC (or white when fc=NULL)
 #' @param mid colour for zero FC
 #' @param high colour for positive FC (or high significance when fc=NULL)
+#' @param na.fill tile fill colour for gene-term combinations with no data (default \code{"grey90"})
+#' @param border.color tile border colour (default \code{"grey40"})
 #' @param label.cutoff absolute FC above which gene names are shown
 #' @param short shorten term names
 #' @param sep gene-ID separator

--- a/man/batchEnrich.Rd
+++ b/man/batchEnrich.Rd
@@ -30,12 +30,12 @@ A list with two elements:
 \describe{
   \item{results}{Named list of richResult objects}
   \item{combined}{Combined data.frame with a \code{group} column,
-    ready for \code{comparedot()}}
+    ready for \code{richCompareDot()}}
 }
 }
 \description{
 Runs enrichment analysis on a named list of gene vectors and returns
-combined results ready for \code{comparedot()} visualization.
+combined results ready for \code{richCompareDot()} visualization.
 }
 \examples{
 \dontrun{
@@ -52,7 +52,7 @@ batch <- batchEnrich(gene_lists, hsako, fun = "richKEGG")
 head(result(batch$results[["Treatment"]]))
 
 # Visualize comparison
-comparedot(batch$combined)
+richCompareDot(batch$combined)
 }
 }
 \author{

--- a/man/batchGSEAplot.Rd
+++ b/man/batchGSEAplot.Rd
@@ -30,7 +30,7 @@ batchGSEAplot(
 
 \item{format}{output format (pdf, png, etc.)}
 
-\item{...}{additional arguments passed to plotGSEA}
+\item{...}{additional arguments passed to richGSEAcurve}
 }
 \description{
 Create multiple GSEA plots for different comparisons

--- a/man/gggeneheat_internal.Rd
+++ b/man/gggeneheat_internal.Rd
@@ -15,6 +15,8 @@ gggeneheat_internal(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",

--- a/man/ggscatter_internal.Rd
+++ b/man/ggscatter_internal.Rd
@@ -6,14 +6,15 @@
 \usage{
 ggscatter_internal(
   resultFis,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,

--- a/man/ggtermsim_internal.Rd
+++ b/man/ggtermsim_internal.Rd
@@ -13,6 +13,8 @@ ggtermsim_internal(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,

--- a/man/ggvolcano_internal.Rd
+++ b/man/ggvolcano_internal.Rd
@@ -9,28 +9,43 @@ ggvolcano_internal(
   top = 50,
   pvalue = 0.05,
   padj = NULL,
-  sig.color = "#b2182b",
-  ns.color = "grey70",
-  point.size = 3,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
   filename = NULL,
   width = 10,
   height = 8
 )
 }
 \arguments{
-\item{resultFis}{data.frame with GSEA results (columns: NES, pval or Pvalue, padj or Padj)}
+\item{resultFis}{data.frame with GSEA or ORA results (columns vary; NES/pval/padj for GSEA, FoldEnrichment/Pvalue/Padj for ORA)}
 
 \item{top}{max number of top terms to display (default 50)}
 
 \item{pvalue}{p-value cutoff}
 
-\item{padj}{adjusted-p cutoff}
+\item{padj}{adjusted-p cutoff (overrides \code{pvalue} when supplied)}
 
-\item{sig.color}{colour for significant points (default \code{"#b2182b"})}
+\item{usePadj}{logical, use adjusted p-value column for significance (default TRUE)}
 
-\item{ns.color}{colour for non-significant points (default \code{"grey70"})}
+\item{low}{colour for down-regulated (negative-effect) points (default \code{"#2166ac"})}
 
-\item{point.size}{point size (default 3)}
+\item{mid}{colour at zero effect (default \code{"white"})}
+
+\item{high}{colour for up-regulated (positive-effect) points (default \code{"#b2182b"})}
+
+\item{size.range}{numeric length-2, min/max point sizes mapped from -log10(p) (default \code{c(2, 8)})}
+
+\item{label.size}{font size for point labels (default 3)}
+
+\item{label.top}{number of top terms to label (default 5)}
+
+\item{short}{logical, shorten term names via \code{.paste.char()} (default FALSE)}
 
 \item{filename}{if non-NULL, save the plot to this file}
 

--- a/man/richCompareDot.Rd
+++ b/man/richCompareDot.Rd
@@ -96,7 +96,7 @@ gene2 <- sample(unique(hsako$GeneID),1000)
 resko1 <-richKEGG(gene1,kodata = hsako)
 resko2 <-richKEGG(gene2,kodata = hsako)
 res<-compareResult(list(S1=resko1,S2=resko2))
-comparedot(res,pvalue=0.05)
+richCompareDot(res, pvalue = 0.05)
 }
 }
 \author{

--- a/man/richGSEAcurve.Rd
+++ b/man/richGSEAcurve.Rd
@@ -124,14 +124,14 @@ gene<-rnorm(1000)
 names(gene)<-name
 res<-richGSEA(gene,object = hsako)
 # Plot with directional coloring (default)
-plotGSEA(object = hsako, gseaRes = res, show_direction = TRUE)
+richGSEAcurve(object = hsako, gseaRes = res, show_direction = TRUE)
 # Plot specific pathways
-plotGSEA(object = hsako, gseaRes = res,
+richGSEAcurve(object = hsako, gseaRes = res,
          pathways = c("MAPK signaling pathway", "PI3K-Akt signaling pathway"))
 # Plot pathways matching pattern
-plotGSEA(object = hsako, gseaRes = res, pathway_pattern = "signaling")
+richGSEAcurve(object = hsako, gseaRes = res, pathway_pattern = "signaling")
 # Traditional multi-color approach
-plotGSEA(object = hsako, gseaRes = res, show_direction = FALSE)
+richGSEAcurve(object = hsako, gseaRes = res, show_direction = FALSE)
 }
 }
 \author{

--- a/man/richGSEAplot.Rd
+++ b/man/richGSEAplot.Rd
@@ -31,7 +31,7 @@ name=sample(unique(hsako$GeneID),1000)
 gene<-rnorm(1000)
 names(gene)<-name
 res<-richGSEA(gene,object = hsako)
-ggGSEA(term = res$pathway, object = hsako, gseaRes = res, default = FALSE)
+richGSEAplot(term = res$pathway, object = hsako, gseaRes = res, default = FALSE)
 }
 }
 \author{

--- a/man/richGeneHeat-methods.Rd
+++ b/man/richGeneHeat-methods.Rd
@@ -20,6 +20,8 @@ richGeneHeat(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",
@@ -40,6 +42,8 @@ richGeneHeat(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",
@@ -60,6 +64,8 @@ richGeneHeat(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",
@@ -80,6 +86,8 @@ richGeneHeat(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",
@@ -100,6 +108,8 @@ richGeneHeat(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",
@@ -120,6 +130,8 @@ richGeneHeat(
   low = "#2166ac",
   mid = "white",
   high = "#b2182b",
+  na.fill = "grey90",
+  border.color = "grey40",
   label.cutoff = 1.5,
   short = FALSE,
   sep = ",",
@@ -149,6 +161,10 @@ richGeneHeat(
 \item{mid}{colour for zero FC}
 
 \item{high}{colour for positive FC (or high significance when fc=NULL)}
+
+\item{na.fill}{tile fill colour for gene-term combinations with no data (default \code{"grey90"})}
+
+\item{border.color}{tile border colour (default \code{"grey40"})}
 
 \item{label.cutoff}{absolute FC above which gene names are shown}
 

--- a/man/richNetmap.Rd
+++ b/man/richNetmap.Rd
@@ -142,7 +142,7 @@ hsago <- buildAnnot(species="human",keytype="SYMBOL",anntype = "GO")
 gene <- sample(unique(hsako$GeneID),1000)
 resko <-richKEGG(gene,kodata = hsako)
 resgo <- richGO(gene,hsago)
-ggnetmap(list(resgo,resko))
+richNetmap(list(resgo, resko))
 }
 }
 \author{

--- a/man/richScatter-methods.Rd
+++ b/man/richScatter-methods.Rd
@@ -7,18 +7,19 @@
 \alias{richScatter,GSEAResult-method}
 \alias{ggscatter}
 \alias{ggScatter}
-\title{Labeled scatter plot of enrichment results}
+\title{Enrichment funnel plot (MA-plot analogy)}
 \usage{
 richScatter(
   object,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,
@@ -28,14 +29,15 @@ richScatter(
 
 \S4method{richScatter}{richResult}(
   object,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,
@@ -45,14 +47,15 @@ richScatter(
 
 \S4method{richScatter}{data.frame}(
   object,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,
@@ -62,14 +65,15 @@ richScatter(
 
 \S4method{richScatter}{GSEAResult}(
   object,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,
@@ -79,14 +83,15 @@ richScatter(
 
 richScatter(
   object,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,
@@ -96,14 +101,15 @@ richScatter(
 
 richScatter(
   object,
-  top = 20,
+  top = 50,
   pvalue = 0.05,
   padj = NULL,
   usePadj = TRUE,
   low = "#fee0d2",
   high = "#b2182b",
-  point.size = 5,
+  point.size = 3,
   label.size = 3,
+  label.top = 5,
   short = FALSE,
   filename = NULL,
   width = 10,
@@ -114,7 +120,7 @@ richScatter(
 \arguments{
 \item{object}{richResult, data.frame, or GSEAResult}
 
-\item{top}{number of terms (default 20)}
+\item{top}{number of terms (default 50)}
 
 \item{pvalue}{p-value cutoff}
 
@@ -128,7 +134,9 @@ richScatter(
 
 \item{point.size}{point size}
 
-\item{label.size}{label size}
+\item{label.size}{label text size}
+
+\item{label.top}{number of top terms to label (via ggrepel)}
 
 \item{short}{shorten term names}
 
@@ -144,7 +152,10 @@ richScatter(
 ggplot2 object
 }
 \description{
-Labeled scatter plot of enrichment results
+Plots pathway size vs fold enrichment, coloured by significance.
+Analogous to an MA plot in differential expression: small pathways
+(left) can have extreme fold enrichment by chance, while large
+pathways (right) with high enrichment are the most robust findings.
 }
 \examples{
 \dontrun{

--- a/man/richTermSim-methods.Rd
+++ b/man/richTermSim-methods.Rd
@@ -7,7 +7,7 @@
 \alias{richTermSim,GSEAResult-method}
 \alias{ggtermsim}
 \alias{ggTermSim}
-\title{Term similarity scatter plot (MDS)}
+\title{Enrichment map — term similarity network}
 \usage{
 richTermSim(
   object,
@@ -18,6 +18,8 @@ richTermSim(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,
@@ -35,6 +37,8 @@ richTermSim(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,
@@ -52,6 +56,8 @@ richTermSim(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,
@@ -69,6 +75,8 @@ richTermSim(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,
@@ -86,6 +94,8 @@ richTermSim(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,
@@ -103,6 +113,8 @@ richTermSim(
   low = "grey80",
   high = "#b2182b",
   label.size = 3,
+  sim.cutoff = 0.2,
+  size.range = c(3, 10),
   short = FALSE,
   sep = ",",
   filename = NULL,
@@ -128,6 +140,10 @@ richTermSim(
 
 \item{label.size}{label size}
 
+\item{sim.cutoff}{minimum Jaccard similarity to draw an edge (0-1)}
+
+\item{size.range}{point size range for gene count mapping}
+
 \item{short}{shorten term names}
 
 \item{sep}{gene-ID separator}
@@ -144,11 +160,15 @@ richTermSim(
 ggplot2 object
 }
 \description{
-Term similarity scatter plot (MDS)
+Positions terms by MDS of gene-set overlap (Jaccard) and draws
+edges between terms that share genes above a similarity cutoff.
+Node size = gene count, colour = -log10(p). Connected clusters
+reveal groups of functionally related pathways.
 }
 \examples{
 \dontrun{
   res <- richKEGG(gene, kodata = hsako)
   richTermSim(res)
+  richTermSim(res, sim.cutoff = 0.3)
 }
 }

--- a/man/richUpset.Rd
+++ b/man/richUpset.Rd
@@ -118,15 +118,15 @@ sets <- list(
   "Treatment B" = c("TP53", "EGFR", "KRAS", "AKT1", "RB1"),
   "Control"     = c("TP53", "MYC", "KRAS", "CDK2", "CCND1")
 )
-ggupset(sets)
+richUpset(sets)
 
 # Custom colors
-ggupset(sets, mycol = c("dodgerblue", "goldenrod1", "seagreen3"))
+richUpset(sets, mycol = c("dodgerblue", "goldenrod1", "seagreen3"))
 
 # From richResult objects
 res1 <- richKEGG(gene1, kodata = hsako)
 res2 <- richKEGG(gene2, kodata = hsako)
-ggupset(list("Sample1" = res1, "Sample2" = res2))
+richUpset(list("Sample1" = res1, "Sample2" = res2))
 }
 }
 \author{

--- a/man/richVolcano-methods.Rd
+++ b/man/richVolcano-methods.Rd
@@ -2,20 +2,45 @@
 % Please edit documentation in R/ggplots_new_methods.R, R/zzz_ggplots_aliases.R
 \name{richVolcano}
 \alias{richVolcano}
+\alias{richVolcano,richResult-method}
 \alias{richVolcano,GSEAResult-method}
 \alias{richVolcano,data.frame-method}
 \alias{ggvolcano}
 \alias{ggVolcano}
-\title{Volcano plot of GSEA gene sets}
+\title{Volcano plot of enrichment results}
 \usage{
 richVolcano(
   object,
   top = 50,
   pvalue = 0.05,
   padj = NULL,
-  sig.color = "#b2182b",
-  ns.color = "grey70",
-  point.size = 3,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
+  filename = NULL,
+  width = 10,
+  height = 8,
+  ...
+)
+
+\S4method{richVolcano}{richResult}(
+  object,
+  top = 50,
+  pvalue = 0.05,
+  padj = NULL,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
   filename = NULL,
   width = 10,
   height = 8,
@@ -27,9 +52,14 @@ richVolcano(
   top = 50,
   pvalue = 0.05,
   padj = NULL,
-  sig.color = "#b2182b",
-  ns.color = "grey70",
-  point.size = 3,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
   filename = NULL,
   width = 10,
   height = 8,
@@ -41,9 +71,14 @@ richVolcano(
   top = 50,
   pvalue = 0.05,
   padj = NULL,
-  sig.color = "#b2182b",
-  ns.color = "grey70",
-  point.size = 3,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
   filename = NULL,
   width = 10,
   height = 8,
@@ -55,9 +90,14 @@ richVolcano(
   top = 50,
   pvalue = 0.05,
   padj = NULL,
-  sig.color = "#b2182b",
-  ns.color = "grey70",
-  point.size = 3,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
   filename = NULL,
   width = 10,
   height = 8,
@@ -69,9 +109,14 @@ richVolcano(
   top = 50,
   pvalue = 0.05,
   padj = NULL,
-  sig.color = "#b2182b",
-  ns.color = "grey70",
-  point.size = 3,
+  usePadj = TRUE,
+  low = "#2166ac",
+  mid = "white",
+  high = "#b2182b",
+  size.range = c(2, 8),
+  label.size = 3,
+  label.top = 5,
+  short = FALSE,
   filename = NULL,
   width = 10,
   height = 8,
@@ -79,7 +124,7 @@ richVolcano(
 )
 }
 \arguments{
-\item{object}{GSEAResult or data.frame with GSEA results}
+\item{object}{richResult, GSEAResult, or data.frame}
 
 \item{top}{max terms (default 50)}
 
@@ -87,11 +132,21 @@ richVolcano(
 
 \item{padj}{adjusted p-value cutoff}
 
-\item{sig.color}{colour for significant points}
+\item{usePadj}{use adjusted p-value for y-axis}
 
-\item{ns.color}{colour for non-significant points}
+\item{low}{low-end gradient colour (negative effect)}
 
-\item{point.size}{point size}
+\item{mid}{midpoint gradient colour}
+
+\item{high}{high-end gradient colour (positive effect)}
+
+\item{size.range}{size range for -log10(p) mapping}
+
+\item{label.size}{label text size}
+
+\item{label.top}{number of top terms to label (via ggrepel)}
+
+\item{short}{shorten term names}
 
 \item{filename}{save path}
 
@@ -105,11 +160,15 @@ richVolcano(
 ggplot2 object
 }
 \description{
-Volcano plot of GSEA gene sets
+For ORA (richResult): x = log2(Fold Enrichment), y = -log10(p), color = effect.
+For GSEA (GSEAResult): x = NES, y = -log10(p), color = NES.
+Point size encodes significance; labels auto-adjusted via ggrepel.
 }
 \examples{
 \dontrun{
-  res <- richGSEA(genelist, gseadata)
-  richVolcano(res)
+  resgo <- richGO(gene, godata = hsago, ontology = "BP")
+  richVolcano(resgo)
+  resgs <- richGSEA(genelist, gseadata)
+  richVolcano(resgs)
 }
 }

--- a/man/saveGSEAplot.Rd
+++ b/man/saveGSEAplot.Rd
@@ -14,7 +14,7 @@ saveGSEAplot(
 )
 }
 \arguments{
-\item{plot_obj}{ggplot object from plotGSEA}
+\item{plot_obj}{ggplot object from richGSEAcurve}
 
 \item{filename}{output filename}
 
@@ -31,7 +31,7 @@ Save GSEA plot with optimal dimensions
 }
 \examples{
 \dontrun{
-p <- plotGSEA(object = hsako, gseaRes = res)
+p <- richGSEAcurve(object = hsako, gseaRes = res)
 saveGSEAplot(p, "gsea_plot.pdf")
 saveGSEAplot(p, "gsea_plot.png", dpi = 600)
 }

--- a/man/theme_richR.Rd
+++ b/man/theme_richR.Rd
@@ -21,10 +21,10 @@ publication-quality figures with legible fonts and minimal clutter.
 \examples{
 \dontrun{
 library(ggplot2)
-ggdot(res) + theme_richR()
+richDot(res) + theme_richR()
 
 # Larger fonts for presentations
-ggbar(res) + theme_richR(base_size = 16)
+richBar(res) + theme_richR(base_size = 16)
 }
 }
 \author{


### PR DESCRIPTION
## Summary

`R CMD check` on current master reports two WARNINGs that block CI (because the workflow uses `error_on = \"warning\"`):

```
* checking for missing documentation entries ... WARNING
  Undocumented S4 methods:
    generic 'richVolcano' and siglist 'richResult'

* checking for code/documentation mismatches ... WARNING
  Codoc mismatches from Rd file 'gggeneheat_internal.Rd'
  Codoc mismatches from Rd file 'ggscatter_internal.Rd'
  Codoc mismatches from Rd file 'ggtermsim_internal.Rd'
  Codoc mismatches from Rd file 'ggvolcano_internal.Rd'
  Codoc mismatches from Rd file 'richGeneHeat-methods.Rd'
  Codoc mismatches from Rd file 'richScatter-methods.Rd'
  Codoc mismatches from Rd file 'richTermSim-methods.Rd'
  Codoc mismatches from Rd file 'richVolcano-methods.Rd'
```

Root cause: the `richVolcano` / `richScatter` / `richTermSim` / `richGeneHeat` redesign commits changed the function signatures, but `man/*.Rd` wasn't refreshed and a couple of roxygen `@param` blocks were left stale.

## What this PR does

1. **Updates two roxygen blocks** where the comments themselves were out of sync with the function body:
   - `R/ggplots_new.R` (`ggvolcano_internal`): three stale `@param` entries (`sig.color`, `ns.color`, `point.size`) no longer exist in the function and are replaced with entries matching the current 11 parameters.
   - `R/ggplots_new_methods.R` (`richGeneHeat` generic): missing `@param` entries for `na.fill` and `border.color` added.
2. **Runs `devtools::document()`** to regenerate 17 `man/*.Rd` files from the current roxygen, including a fresh `richUpset.Rd` that covers the previously undocumented S4 method.

No R code behavior changes. NAMESPACE is unchanged.

## Before / after

```
Before: Status: 2 WARNINGs, 4 NOTEs   (CI fails on warnings)
After:  Status:              4 NOTEs   (CI passes)
```

Verified locally with R 4.5.3 in a conda env that matches the CI dependency set.

## Files changed

- `R/ggplots_new.R` (roxygen @param updates)
- `R/ggplots_new_methods.R` (roxygen @param additions)
- `man/*.Rd` (17 files, regenerated from roxygen)

## Relation to other PRs

Independent of #9 (richUpset alignment + color blending). Either can merge first. If #9 merges first, the only conflict here would be on `richUpset.Rd` — `devtools::document()` on top of #9 would include the updated `richUpset` `@param main.bar.color` wording automatically.